### PR TITLE
Update GeoHashes.js so that we trim excess empty lines

### DIFF
--- a/map-viz-app/src/components/GeoHashes/GeoHashes.js
+++ b/map-viz-app/src/components/GeoHashes/GeoHashes.js
@@ -58,6 +58,7 @@ class GeoHashes extends Component {
         var geohashes = this
             .vars
             .geohashes
+            .trim()
             .split("\n");
 
         var geohashesL = [];


### PR DESCRIPTION
I found this site to be really helpful. One annoying thing is when you paste geo hashes in the input box and it has extra new lines. I haven't really tested this but I assume this tiny trim would get rid of the excess. Let me know if it doesn't. Happy to help.